### PR TITLE
Fix: Add Docker same-host deployment with existing Ollama service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,34 @@
 # Olympian AI Lightweight Makefile
 # Simplifies common development and deployment tasks
 
-.PHONY: help install dev build test lint format clean docker-build docker-dev docker-prod-same docker-prod-multi setup env-dev env-docker-same env-docker-multi
+.PHONY: help install dev build test lint format clean docker-build docker-dev docker-prod-same docker-prod-multi setup env-dev env-docker-same env-docker-same-existing env-docker-multi
 
 # Default target
 help:
 	@echo "Olympian AI Lightweight - Available commands:"
 	@echo ""
 	@echo "Setup & Environment:"
-	@echo "  make setup            Run initial setup"
-	@echo "  make env-dev          Configure .env for development (auto-generates secrets)"
-	@echo "  make env-docker-same  Configure .env for Docker same-host (auto-generates secrets)"
-	@echo "  make env-docker-multi Configure .env for Docker multi-host (auto-generates secrets)"
+	@echo "  make setup                  Run initial setup"
+	@echo "  make env-dev                Configure .env for development (auto-generates secrets)"
+	@echo "  make env-docker-same        Configure .env for Docker same-host with Ollama container (auto-generates secrets)"
+	@echo "  make env-docker-same-existing Configure .env for Docker same-host with existing host Ollama (auto-generates secrets)"
+	@echo "  make env-docker-multi       Configure .env for Docker multi-host (auto-generates secrets)"
 	@echo ""
 	@echo "Development:"
-	@echo "  make install          Install dependencies"
-	@echo "  make dev              Start development servers"
-	@echo "  make build            Build all packages"
-	@echo "  make test             Run tests"
-	@echo "  make lint             Run linter"
-	@echo "  make format           Format code"
-	@echo "  make clean            Clean build artifacts"
+	@echo "  make install                Install dependencies"
+	@echo "  make dev                    Start development servers"
+	@echo "  make build                  Build all packages"
+	@echo "  make test                   Run tests"
+	@echo "  make lint                   Run linter"
+	@echo "  make format                 Format code"
+	@echo "  make clean                  Clean build artifacts"
 	@echo ""
 	@echo "Docker Deployment:"
-	@echo "  make docker-dev       Run development environment in Docker"
-	@echo "  make docker-same      Deploy production (same-host)"
-	@echo "  make docker-multi     Deploy production (multi-host)"
-	@echo "  make docker-build     Build Docker images only"
+	@echo "  make docker-dev             Run development environment in Docker"
+	@echo "  make docker-same            Deploy production (same-host with Ollama container)"
+	@echo "  make docker-same-existing   Deploy production (same-host with existing host Ollama)"
+	@echo "  make docker-multi           Deploy production (multi-host)"
+	@echo "  make docker-build           Build Docker images only"
 	@echo ""
 
 # Development commands
@@ -61,6 +63,13 @@ docker-dev:
 docker-same:
 	./scripts/docker-deploy.sh --same-host
 
+docker-same-existing:
+	@echo "🚀 Deploying with existing host Ollama service..."
+	@docker compose -f docker-compose.same-host-existing-ollama.yml down
+	@docker compose -f docker-compose.same-host-existing-ollama.yml up -d
+	@echo "✅ Deployment complete! Access at http://localhost:${APP_PORT:-8080}"
+	@echo "ℹ️  Using Ollama service running on host at localhost:11434"
+
 docker-multi:
 	./scripts/docker-deploy.sh --multi-host
 
@@ -86,7 +95,7 @@ env-dev:
 	@echo "✅ Development configuration applied with secure secrets"
 
 env-docker-same:
-	@echo "🔧 Configuring .env for Docker same-host deployment..."
+	@echo "🔧 Configuring .env for Docker same-host deployment (with Ollama container)..."
 	@if [ ! -f .env ]; then cp .env.example .env; fi
 	@sed -i.bak 's|^DEPLOYMENT_MODE=.*|DEPLOYMENT_MODE=docker-same-host|' .env
 	@sed -i.bak 's|^MONGODB_URI=.*|# MONGODB_URI=mongodb://localhost:27017/olympian_ai_lite|' .env
@@ -100,6 +109,24 @@ env-docker-same:
 	sed -i.bak "s|^SESSION_SECRET=.*|SESSION_SECRET=$$SESSION_SECRET|" .env
 	@rm -f .env.bak
 	@echo "✅ Docker same-host configuration applied with secure secrets"
+
+env-docker-same-existing:
+	@echo "🔧 Configuring .env for Docker same-host deployment (with existing host Ollama)..."
+	@if [ ! -f .env ]; then cp .env.example .env; fi
+	@sed -i.bak 's|^DEPLOYMENT_MODE=.*|DEPLOYMENT_MODE=same-host-existing-ollama|' .env
+	@sed -i.bak 's|^MONGODB_URI=.*|# MONGODB_URI=mongodb://localhost:27017/olympian_ai_lite|' .env
+	@sed -i.bak 's|^# MONGODB_URI=mongodb://olympian-mongodb|MONGODB_URI=mongodb://olympian-mongodb|' .env
+	@sed -i.bak 's|^OLLAMA_HOST=.*|OLLAMA_HOST=http://host.docker.internal:11434|' .env
+	@sed -i.bak 's|^# OLLAMA_HOST=http://olympian-ollama|# OLLAMA_HOST=http://olympian-ollama:11434|' .env
+	@sed -i.bak 's|^# OLLAMA_HOST=http://192.168.1.11|# OLLAMA_HOST=http://192.168.1.11:11434|' .env
+	@echo "🔐 Generating secure secrets..."
+	@JWT_SECRET=$$(openssl rand -base64 32); \
+	SESSION_SECRET=$$(openssl rand -base64 32); \
+	sed -i.bak "s|^JWT_SECRET=.*|JWT_SECRET=$$JWT_SECRET|" .env; \
+	sed -i.bak "s|^SESSION_SECRET=.*|SESSION_SECRET=$$SESSION_SECRET|" .env
+	@rm -f .env.bak
+	@echo "✅ Docker same-host with existing Ollama configuration applied with secure secrets"
+	@echo "ℹ️  Using Ollama service running on host at localhost:11434"
 
 env-docker-multi:
 	@echo "🔧 Configuring .env for Docker multi-host deployment..."
@@ -143,11 +170,17 @@ logs-dev:
 logs-prod:
 	docker compose -f docker-compose.prod.yml logs -f
 
+logs-same-existing:
+	docker compose -f docker-compose.same-host-existing-ollama.yml logs -f
+
 stop-dev:
 	docker compose down
 
 stop-prod:
 	docker compose -f docker-compose.prod.yml down
+
+stop-same-existing:
+	docker compose -f docker-compose.same-host-existing-ollama.yml down
 
 # Health checks
 health-check:
@@ -195,9 +228,14 @@ quick-dev:
 	@make dev
 
 quick-docker-same:
-	@echo "🚀 Quick Docker same-host deployment..."
+	@echo "🚀 Quick Docker same-host deployment (with Ollama container)..."
 	@make env-docker-same
 	@make docker-same
+
+quick-docker-same-existing:
+	@echo "🚀 Quick Docker same-host deployment (with existing host Ollama)..."
+	@make env-docker-same-existing
+	@make docker-same-existing
 
 quick-docker-multi:
 	@echo "🚀 Quick Docker multi-host deployment..."

--- a/README.md
+++ b/README.md
@@ -48,11 +48,18 @@ make setup
 make quick-dev
 ```
 
-#### Option B: Docker Same-Host (One Command)
+#### Option B: Docker Same-Host with Ollama Container (One Command)
 
 ```bash
-# Configure and deploy same-host Docker (auto-generates secure secrets)
+# Configure and deploy same-host Docker with containerized Ollama (auto-generates secure secrets)
 make quick-docker-same
+```
+
+#### Option B2: Docker Same-Host with Existing Ollama (One Command) ⭐ NEW
+
+```bash
+# Configure and deploy same-host Docker using existing host Ollama (auto-generates secure secrets)
+make quick-docker-same-existing
 ```
 
 #### Option C: Docker Multi-Host
@@ -74,13 +81,17 @@ If you prefer more control:
 
 ```bash
 # Step 1: Configure environment (automatically generates secure secrets)
-make env-docker-same     # or env-dev, env-docker-multi
+make env-docker-same              # Docker with Ollama container
+make env-docker-same-existing     # Docker with existing host Ollama
+# or env-dev, env-docker-multi
 
 # Step 2: Check configuration
 make show-env
 
 # Step 3: Deploy
-make docker-same         # or dev, docker-multi
+make docker-same                  # Docker with Ollama container
+make docker-same-existing         # Docker with existing host Ollama
+# or dev, docker-multi
 ```
 
 ## Environment Configuration
@@ -90,7 +101,8 @@ The application uses a single `.env` file that's automatically configured:
 ### 🔧 Automatic Configuration Commands
 
 - `make env-dev` - Configure for development + generate secrets
-- `make env-docker-same` - Configure for Docker same-host + generate secrets  
+- `make env-docker-same` - Configure for Docker same-host with Ollama container + generate secrets
+- `make env-docker-same-existing` - Configure for Docker same-host with existing host Ollama + generate secrets ⭐ NEW
 - `make env-docker-multi` - Configure for Docker multi-host + generate secrets
 
 All environment commands automatically:
@@ -101,53 +113,59 @@ All environment commands automatically:
 ### 🚀 One-Step Deployment Commands
 
 - `make quick-dev` - Configure + start development
-- `make quick-docker-same` - Configure + deploy Docker same-host
+- `make quick-docker-same` - Configure + deploy Docker same-host with Ollama container
+- `make quick-docker-same-existing` - Configure + deploy Docker same-host with existing host Ollama ⭐ NEW
 
 ## Available Commands
 
 ### Setup & Environment
 ```bash
-make setup              # Initial project setup
-make env-dev            # Configure for development (auto-generates secrets)
-make env-docker-same    # Configure for Docker same-host (auto-generates secrets)
-make env-docker-multi   # Configure for Docker multi-host (auto-generates secrets)
-make show-env           # Show current configuration and security status
-make apply-secrets      # Generate and apply new secrets to existing .env
+make setup                        # Initial project setup
+make env-dev                      # Configure for development (auto-generates secrets)
+make env-docker-same              # Configure for Docker same-host with Ollama container (auto-generates secrets)
+make env-docker-same-existing     # Configure for Docker same-host with existing host Ollama (auto-generates secrets)
+make env-docker-multi             # Configure for Docker multi-host (auto-generates secrets)
+make show-env                     # Show current configuration and security status
+make apply-secrets                # Generate and apply new secrets to existing .env
 ```
 
 ### Quick Deployment
 ```bash
-make quick-dev          # One-step development setup
-make quick-docker-same  # One-step Docker same-host deployment
+make quick-dev                    # One-step development setup
+make quick-docker-same            # One-step Docker same-host deployment (with Ollama container)
+make quick-docker-same-existing   # One-step Docker same-host deployment (with existing host Ollama)
 ```
 
 ### Development
 ```bash
-make dev                # Start development servers
-make build              # Build all packages
-make test               # Run tests
-make lint               # Run linter
-make format             # Format code
-make clean              # Clean build artifacts
+make dev                          # Start development servers
+make build                        # Build all packages
+make test                         # Run tests
+make lint                         # Run linter
+make format                       # Format code
+make clean                        # Clean build artifacts
 ```
 
 ### Docker Deployment
 ```bash
-make docker-dev         # Run development in Docker
-make docker-same        # Production deployment (same-host)
-make docker-multi       # Production deployment (multi-host)
-make docker-build       # Build Docker images only
+make docker-dev                   # Run development in Docker
+make docker-same                  # Production deployment (same-host with Ollama container)
+make docker-same-existing         # Production deployment (same-host with existing host Ollama)
+make docker-multi                 # Production deployment (multi-host)
+make docker-build                 # Build Docker images only
 ```
 
 ### Monitoring & Maintenance
 ```bash
-make health-check       # Check service health
-make logs-dev           # View development logs
-make logs-prod          # View production logs
-make stop-dev           # Stop development containers
-make stop-prod          # Stop production containers
-make db-backup          # Backup MongoDB
-make db-restore         # Restore MongoDB from latest backup
+make health-check                 # Check service health
+make logs-dev                     # View development logs
+make logs-prod                    # View production logs
+make logs-same-existing           # View logs for same-host with existing Ollama deployment
+make stop-dev                     # Stop development containers
+make stop-prod                    # Stop production containers
+make stop-same-existing           # Stop same-host with existing Ollama containers
+make db-backup                    # Backup MongoDB
+make db-restore                   # Restore MongoDB from latest backup
 ```
 
 ## Usage
@@ -162,7 +180,35 @@ make db-restore         # Restore MongoDB from latest backup
 
 4. **Start chatting**: Select a model in Divine Dialog and start conversing
 
-## Example Deployment Configurations
+## Deployment Configurations
+
+Choose the deployment option that best fits your setup:
+
+### 🏠 Development (make env-dev)
+Best for: Local development and testing
+- Ollama: Uses existing host installation at `localhost:11434`
+- MongoDB: Uses local MongoDB installation
+- All services run natively on host
+
+### 🐳 Docker Same-Host with Ollama Container (make env-docker-same)
+Best for: Production deployment where you want everything containerized
+- Ollama: Downloads and runs in Docker container
+- MongoDB: Runs in Docker container
+- All services isolated in containers
+
+### 🐳⚡ Docker Same-Host with Existing Ollama (make env-docker-same-existing) ⭐ NEW
+Best for: Production deployment where Ollama is already running on host
+- Ollama: Uses existing host installation via `host.docker.internal:11434`
+- MongoDB: Runs in Docker container
+- Hybrid approach - existing Ollama + containerized app services
+
+### 🌐 Docker Multi-Host (make env-docker-multi)
+Best for: Distributed deployment across multiple servers
+- Ollama: Uses remote Ollama server
+- MongoDB: Uses remote MongoDB server
+- App services in containers, external dependencies on separate hosts
+
+## Example Environment Configurations
 
 After running the environment commands, your `.env` will be automatically configured:
 
@@ -175,11 +221,20 @@ JWT_SECRET=<auto-generated-secure-secret>
 SESSION_SECRET=<auto-generated-secure-secret>
 ```
 
-### Docker Same-Host Setup (make env-docker-same)
+### Docker Same-Host with Ollama Container (make env-docker-same)
 ```bash
 DEPLOYMENT_MODE=docker-same-host
 MONGODB_URI=mongodb://olympian-mongodb:27017/olympian_ai_lite
 OLLAMA_HOST=http://olympian-ollama:11434
+JWT_SECRET=<auto-generated-secure-secret>
+SESSION_SECRET=<auto-generated-secure-secret>
+```
+
+### Docker Same-Host with Existing Ollama (make env-docker-same-existing) ⭐ NEW
+```bash
+DEPLOYMENT_MODE=same-host-existing-ollama
+MONGODB_URI=mongodb://olympian-mongodb:27017/olympian_ai_lite
+OLLAMA_HOST=http://host.docker.internal:11434
 JWT_SECRET=<auto-generated-secure-secret>
 SESSION_SECRET=<auto-generated-secure-secret>
 ```
@@ -201,7 +256,7 @@ SESSION_SECRET=<auto-generated-secure-secret>
 make show-env
 
 # Reconfigure for your deployment mode (auto-generates new secrets)
-make env-dev          # or env-docker-same, env-docker-multi
+make env-dev                      # or env-docker-same, env-docker-same-existing, env-docker-multi
 
 # Apply new secrets to existing configuration
 make apply-secrets
@@ -210,13 +265,27 @@ make apply-secrets
 ### Docker Issues
 ```bash
 # Check service logs
-make logs-prod
+make logs-prod                    # For standard same-host deployment
+make logs-same-existing           # For same-host with existing Ollama
 
 # Restart services
-docker compose -f docker-compose.same-host.yml restart
+docker compose -f docker-compose.same-host.yml restart                    # Standard same-host
+docker compose -f docker-compose.same-host-existing-ollama.yml restart    # Same-host with existing Ollama
 
 # Rebuild images
 make docker-build
+```
+
+### Ollama Connection Issues (Existing Host Ollama)
+```bash
+# Verify Ollama is running on host
+curl http://localhost:11434/api/tags
+
+# Check if Docker can reach host Ollama
+docker run --rm --add-host host.docker.internal:host-gateway curlimages/curl curl -s http://host.docker.internal:11434/api/tags
+
+# View container logs to debug connection
+make logs-same-existing
 ```
 
 ### Development Issues
@@ -233,19 +302,23 @@ make dev
 
 ```
 olympian-ai-lightweight/
-├── .env.example         # Environment template (committed)
-├── .env                # Your configuration (gitignored, auto-generated)
+├── .env.example                                    # Environment template (committed)
+├── .env                                           # Your configuration (gitignored, auto-generated)
+├── docker-compose.yml                             # Development Docker setup
+├── docker-compose.same-host.yml                   # Same-host with Ollama container
+├── docker-compose.same-host-existing-ollama.yml   # Same-host with existing Ollama ⭐ NEW
+├── docker-compose.prod.yml                        # Production setup
 ├── packages/
-│   ├── client/          # React frontend
-│   ├── server/          # Express backend
-│   └── shared/          # Shared types and utilities
-├── docker/              # Docker configurations
-│   ├── frontend/        # Frontend Dockerfile
-│   ├── backend/         # Backend Dockerfile
-│   └── nginx/           # Nginx configuration
-├── scripts/             # Setup and deployment scripts
-├── docs/                # Documentation
-└── Makefile            # Automation commands
+│   ├── client/                                    # React frontend
+│   ├── server/                                    # Express backend
+│   └── shared/                                    # Shared types and utilities
+├── docker/                                        # Docker configurations
+│   ├── frontend/                                  # Frontend Dockerfile
+│   ├── backend/                                   # Backend Dockerfile
+│   └── nginx/                                     # Nginx configuration
+├── scripts/                                       # Setup and deployment scripts
+├── docs/                                          # Documentation
+└── Makefile                                       # Automation commands
 ```
 
 ## Security Features

--- a/docker-compose.same-host-existing-ollama.yml
+++ b/docker-compose.same-host-existing-ollama.yml
@@ -1,0 +1,91 @@
+# Docker Compose for same-host deployment with existing Ollama
+# Uses Ollama service already running on the host (no Ollama container)
+# MongoDB and other services run in containers
+
+services:
+  # Application services
+  frontend:
+    build:
+      context: .
+      dockerfile: docker/frontend/Dockerfile
+    container_name: olympian-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    networks:
+      - olympian-network
+
+  backend:
+    build:
+      context: .
+      dockerfile: docker/backend/Dockerfile
+    container_name: olympian-backend
+    restart: unless-stopped
+    environment:
+      DEPLOYMENT_MODE: same-host-existing-ollama
+      MONGODB_URI: mongodb://olympian-mongodb:27017/olympian_ai_lite
+      OLLAMA_HOST: http://host.docker.internal:11434
+      NODE_ENV: production
+      PORT: 4000
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      JWT_SECRET: ${JWT_SECRET}
+      SESSION_SECRET: ${SESSION_SECRET}
+    volumes:
+      - config-data:/config/.olympian-ai-lite
+      - logs:/app/logs
+    depends_on:
+      - mongodb
+    networks:
+      - olympian-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  nginx:
+    build:
+      context: .
+      dockerfile: docker/nginx/Dockerfile
+    container_name: olympian-nginx
+    restart: unless-stopped
+    environment:
+      DEPLOYMENT_MODE: same-host-existing-ollama
+    ports:
+      - "${APP_PORT:-8080}:80"
+    depends_on:
+      - frontend
+      - backend
+    networks:
+      - olympian-network
+
+  # Database service only (Ollama runs on host)
+  mongodb:
+    image: mongo:7
+    container_name: olympian-mongodb
+    restart: unless-stopped
+    volumes:
+      - mongodb-data:/data/db
+    environment:
+      MONGO_INITDB_DATABASE: olympian_ai_lite
+    networks:
+      - olympian-network
+
+  # Example MCP server
+  mcp-filesystem:
+    image: node:20-alpine
+    container_name: olympian-mcp-filesystem
+    restart: unless-stopped
+    working_dir: /app
+    command: npx -y @modelcontextprotocol/server-filesystem /data
+    volumes:
+      - mcp-data:/data
+    networks:
+      - olympian-network
+
+volumes:
+  config-data:
+  logs:
+  mongodb-data:
+  mcp-data:
+
+networks:
+  olympian-network:
+    driver: bridge


### PR DESCRIPTION
## Problem
The current `docker-compose.same-host.yml` unnecessarily downloads and runs Ollama in a container even when Ollama is already running on the host. This creates resource overhead and duplicates services.

## Solution
Added a new deployment option for same-host Docker deployment that uses the existing host Ollama service instead of containerizing it.

## Changes Made

### 🆕 New Files
- **`docker-compose.same-host-existing-ollama.yml`**: New Docker Compose configuration that:
  - Removes the Ollama service entirely 
  - Uses `host.docker.internal:11434` to connect to host's Ollama
  - Keeps MongoDB and other services containerized
  - Adds proper networking configuration for host access

### 🔧 Updated Files
- **`Makefile`**: Added new targets:
  - `env-docker-same-existing`: Configure environment for existing host Ollama
  - `docker-same-existing`: Deploy using existing host Ollama
  - `quick-docker-same-existing`: One-step deployment with existing Ollama
  - Additional logging and management targets

- **`README.md`**: Comprehensive documentation updates:
  - New deployment option clearly explained
  - Updated command reference
  - Configuration examples for all scenarios
  - Troubleshooting section for Ollama connectivity
  - Clear distinction between containerized vs existing Ollama options

## Usage

### Quick Start (One Command)
```bash
make quick-docker-same-existing
```

### Step by Step
```bash
# Configure environment
make env-docker-same-existing

# Deploy 
make docker-same-existing
```

## Benefits
- ✅ **No unnecessary Ollama download**: Uses existing host installation
- ✅ **Resource efficient**: Eliminates duplicate Ollama containers
- ✅ **Hybrid approach**: Containerized app services + existing Ollama
- ✅ **Easy migration**: Simple switch from containerized to existing Ollama
- ✅ **Clear documentation**: Well-documented deployment options

## Testing
- [ ] Verify host Ollama connectivity via `host.docker.internal:11434`
- [ ] Test container deployment without Ollama service
- [ ] Validate environment configuration 
- [ ] Confirm MongoDB containerization works correctly

Fixes the issue where the same-host version unnecessarily downloads Ollama when it's already running on the host.