### PR TITLE
Fix: TypeScript compilation errors in chat.ts

### DIFF
--- a/packages/server/src/api/chat.ts
+++ b/packages/server/src/api/chat.ts
@@ -4,6 +4,7 @@ import { OllamaStreamliner } from '../services/OllamaStreamliner';
 import { AppError } from '../middleware/errorHandler';
 import { chatRateLimiter } from '../middleware/rateLimiter';
 import { z } from 'zod';
+import { Message } from '@olympian/shared';
 
 const router = Router();
 const db = DatabaseService.getInstance();
@@ -26,7 +27,7 @@ router.post('/send', async (req, res, next) => {
     // Validate input
     const validation = sendMessageSchema.safeParse(req.body);
     if (!validation.success) {
-      throw new AppError(400, 'Invalid request body', validation.error.errors);
+      throw new AppError(400, 'Invalid request body');
     }
 
     const { message, conversationId, model, images } = validation.data;
@@ -49,7 +50,7 @@ router.post('/send', async (req, res, next) => {
     // Save user message
     await db.messages.insertOne({
       conversationId: convId,
-      role: 'user',
+      role: 'user' as const,
       content: message,
       images,
       createdAt: new Date(),
@@ -74,9 +75,9 @@ router.post('/send', async (req, res, next) => {
     });
 
     // Save assistant message
-    const assistantMessage = {
+    const assistantMessage: Message = {
       conversationId: convId,
-      role: 'assistant',
+      role: 'assistant' as const,
       content: assistantContent,
       metadata: {
         model,


### PR DESCRIPTION
## Fix TypeScript compilation errors in chat.ts

This PR fixes the TypeScript compilation errors introduced in the previous PR that added the `/api/chat/send` endpoint.

### Fixes:
1. **AppError constructor call**: Removed the third parameter (validation errors) as AppError only accepts `statusCode` and `message`
2. **Type literal for role field**: Added `as const` assertions to ensure the role strings match the literal union type `'user' | 'assistant' | 'system'`
3. **Import Message type**: Added import for the Message type from `@olympian/shared` to ensure proper typing

### Changes:
- Line 7: Added `import { Message } from '@olympian/shared';`
- Line 29: Changed `throw new AppError(400, 'Invalid request body', validation.error.errors);` to `throw new AppError(400, 'Invalid request body');`
- Line 52: Added `as const` to `role: 'user' as const,`
- Line 78: Added `as const` to `role: 'assistant' as const,`
- Line 77: Properly typed `assistantMessage` as `Message`

These changes fix the compilation errors while maintaining the intended functionality.