### PR TITLE
Fix nginx timeout for vision processing

### DIFF
--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -15,19 +15,41 @@ server {
         try_files $uri $uri/ /index.html;
     }
     
-    # API proxy
+    # API proxy with extended timeouts for vision processing
     location /api {
         proxy_pass http://backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # Extended timeouts for vision processing
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 300s;        # 5 minutes
+        proxy_read_timeout 300s;        # 5 minutes
+        proxy_buffer_size 4k;
+        proxy_buffers 8 4k;
+        proxy_busy_buffers_size 8k;
     }
     
-    # WebSocket proxy
+    # WebSocket proxy with extended timeouts
     location /socket.io {
         proxy_pass http://backend;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # Extended timeouts for long-running chat sessions
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 300s;        # 5 minutes  
+        proxy_read_timeout 300s;        # 5 minutes
+        
+        # WebSocket specific settings
+        proxy_buffering off;
+        proxy_cache off;
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes the nginx timeout issue that was preventing vision processing from completing with slower models like `qwen2.5vl:7b`.

## 🐛 **Problem**
- **Timeout Error**: `upstream timed out (110: Operation timed out) while reading response header from upstream`
- **Root Cause**: nginx default timeout (~60s) was too short for vision processing
- **Impact**: Vision processing would start but timeout before completing, especially with slower models

## 🔧 **Solution**

### **Extended Nginx Timeouts**
- **proxy_read_timeout**: Increased to **5 minutes (300s)** for vision processing
- **proxy_send_timeout**: Increased to **5 minutes (300s)** for large image uploads
- **proxy_connect_timeout**: Set to **30s** for initial connection

### **Enhanced Proxy Configuration**
- Added proper proxy headers for better upstream communication
- **WebSocket optimizations**: Disabled buffering for real-time streaming
- Added proxy buffer settings for better performance
- Extended timeouts for both API and WebSocket routes

## 🎯 **Expected Results**

After this fix:
1. ✅ **qwen2.5vl:7b** vision processing should complete without timeout
2. ✅ **Slower vision models** will have adequate time to process images  
3. ✅ **WebSocket streaming** will be more reliable for long responses
4. ✅ **No more 504 Gateway Timeout** errors for vision requests

## 🧪 **Technical Details**

### **Before**
```
2025/06/16 12:42:28 [error] upstream timed out (110: Operation timed out)
```

### **After**  
- API requests: Up to 5 minutes processing time
- WebSocket connections: Up to 5 minutes for streaming
- Improved buffering and headers for better performance

This should resolve the timeout issue and allow successful vision processing with any Ollama vision model, regardless of processing speed.