### PR TITLE
Fix MongoDB connection for host networking in multi-host deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,11 +206,12 @@ env-docker-multi-interactive: ## Interactive multi-host environment configuratio
 	sed -i.bak 's|^OLLAMA_HOST=.*|OLLAMA_HOST='"$$ollama_url"'|' .env
 	@echo ""
 	@echo "$(CYAN)🗄️  MongoDB Configuration:$(RESET)"
+	@echo "$(YELLOW)Note: Backend uses host networking mode, so containerized MongoDB will be accessible via localhost:27017$(RESET)"
 	@printf "Use default MongoDB setup? (y/N): "; \
 	read use_default_mongo; \
 	if [ "$$use_default_mongo" = "y" ] || [ "$$use_default_mongo" = "Y" ]; then \
-		sed -i.bak 's|^MONGODB_URI=.*|MONGODB_URI=mongodb://olympian-mongodb:27017/olympian_ai_lite|' .env; \
-		echo "$(GREEN)✅ Using containerized MongoDB$(RESET)"; \
+		sed -i.bak 's|^MONGODB_URI=.*|MONGODB_URI=mongodb://localhost:27017/olympian_ai_lite|' .env; \
+		echo "$(GREEN)✅ Using containerized MongoDB (accessible via localhost due to host networking)$(RESET)"; \
 	else \
 		printf "Enter MongoDB host (IP address or DNS name, or press Enter to use containerized MongoDB): "; \
 		read mongo_host; \
@@ -227,8 +228,8 @@ env-docker-multi-interactive: ## Interactive multi-host environment configuratio
 			sed -i.bak 's|^MONGODB_URI=.*|MONGODB_URI='"$$mongo_uri"'|' .env; \
 			echo "$(GREEN)✅ MongoDB configured for external host: $$mongo_host$(RESET)"; \
 		else \
-			sed -i.bak 's|^MONGODB_URI=.*|MONGODB_URI=mongodb://olympian-mongodb:27017/olympian_ai_lite|' .env; \
-			echo "$(GREEN)✅ Using containerized MongoDB$(RESET)"; \
+			sed -i.bak 's|^MONGODB_URI=.*|MONGODB_URI=mongodb://localhost:27017/olympian_ai_lite|' .env; \
+			echo "$(GREEN)✅ Using containerized MongoDB (accessible via localhost due to host networking)$(RESET)"; \
 		fi; \
 	fi
 	@echo ""


### PR DESCRIPTION
## Description
This PR fixes the MongoDB connection issue in multi-host deployments where the backend uses host networking mode.

## Problem
When running `make quick-docker-multi` with the default MongoDB setup, the backend was failing with:
```
MongoServerSelectionError: getaddrinfo ENOTFOUND olympian-mongodb
```

This occurred because:
1. The backend container uses `network_mode: host` to access external services like Ollama
2. With host networking, containers can't be accessed by their container names
3. The MongoDB URI was set to `mongodb://olympian-mongodb:27017/olympian_ai_lite`

## Solution
- Updated the `env-docker-multi-interactive` target to use `localhost:27017` for containerized MongoDB
- Added explanatory note about host networking implications
- MongoDB container exposes port 27017 to the host, making it accessible via localhost

## Changes
- When users choose the default MongoDB setup in multi-host mode:
  - MongoDB URI is now set to `mongodb://localhost:27017/olympian_ai_lite`
  - Clear messaging explains why localhost is used

## Testing
After this fix:
1. Backend can successfully connect to MongoDB
2. Application starts properly in multi-host deployment mode
3. External Ollama services remain accessible