### PR TITLE
Fix Ollama connection in Docker same-host-existing mode

### DIFF
--- a/docker-compose.same-host-existing-ollama.yml
+++ b/docker-compose.same-host-existing-ollama.yml
@@ -42,6 +42,7 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-info}
       JWT_SECRET: ${JWT_SECRET}
       SESSION_SECRET: ${SESSION_SECRET}
+      RUNNING_IN_DOCKER: "true"
     volumes:
       - config-data:/config/.olympian-ai-lite
       - logs:/app/logs


### PR DESCRIPTION
## Description
This PR fixes the Ollama connection issue in the Docker environment for the `same-host-existing-ollama` deployment mode.

## Problem
The backend was failing to connect to Ollama with the error:
```
olympian-backend  | 2025-06-16 15:22:37 [error]: 🔗 Network connection failed to Ollama server:
```

The issue was that the backend was:
1. Initializing in `development` mode instead of `same-host-existing-ollama` mode
2. Not properly detecting it was running in Docker, causing it to use `localhost:11434` instead of `host.docker.internal:11434`

## Solution
Added the `RUNNING_IN_DOCKER: "true"` environment variable to the backend service in `docker-compose.same-host-existing-ollama.yml`. This ensures the Docker detection logic in `deployment.ts` works correctly and uses `host.docker.internal:11434` to connect to the host's Ollama service.

## Testing
After this change, the backend should:
- Properly detect it's running in Docker
- Use `http://host.docker.internal:11434` for Ollama connections
- Successfully connect to the Ollama service running on the host machine

## Related Issues
Fixes Ollama connection issues in Docker environments when using existing host Ollama installation.